### PR TITLE
Add sushiswap LP strategy to COVER

### DIFF
--- a/spaces/cover/index.json
+++ b/spaces/cover/index.json
@@ -20,6 +20,13 @@
         "symbol": "COVER (Uniswap)"
       }
     }
+    {
+      "name": "sushiswap",
+      "params": {
+        "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
+        "symbol": "COVER (Sushiswap)"
+      }
+    }
   ],
   "members": [
     "0x2f80E5163A7A774038753593010173322eA6f9fe",


### PR DESCRIPTION
This PR adds a sushiswap strategy to the COVER space.

Please confirm it is correct.

Thank you! 